### PR TITLE
Updated comment form to hide delete from non-owner using agnostic current user method

### DIFF
--- a/app/views/opinio/comments/_comment.html.erb
+++ b/app/views/opinio/comments/_comment.html.erb
@@ -4,7 +4,9 @@
   <p>
     <%= simple_format(comment.body) %>
   </p>
-  <%= link_to t('opinio.actions.delete'), comment_path(comment), :method => :delete, :remote => true %>
+  <% if comment.owner == send(Opinio.current_user_method) %>
+    <%= link_to t('opinio.actions.delete'), comment_path(comment), :method => :delete, :remote => true %>
+  <% end %>
   <%# this enables only 1 level of replies %>
   <% if Opinio.accept_replies && !reply %>
     <span><%= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true %></span>


### PR DESCRIPTION
Good point on the current user method; I think this way should work; it should call Opinio's stored method as a constant, matching it thusly.  
