### PR TITLE
Manage replies on the client side

### DIFF
--- a/app/assets/javascripts/opinio/opinio.js.coffee
+++ b/app/assets/javascripts/opinio/opinio.js.coffee
@@ -14,3 +14,11 @@ $ ->
     $(this).hide()
     false
 
+  $(document).on 'keyup', '.comment_body, .reply_body',(e) ->
+    disabled = true
+    if $(this).val() != ''
+      disabled = false
+    if disabled
+      $(this).siblings('input[type=submit]').attr('disabled', 'disabled');
+    else
+      $(this).siblings('input[type=submit]').removeAttr('disabled');

--- a/app/assets/javascripts/opinio/opinio.js.coffee
+++ b/app/assets/javascripts/opinio/opinio.js.coffee
@@ -1,0 +1,16 @@
+$ ->
+  $('a.reply_link').on 'click', (e) ->
+    $link = $(this)
+    $reply = $('#reply_template').clone()
+    $reply.appendTo($(this).parent('section').parent())
+
+    id = $link.data('commentable-id')
+    $reply.find('#commentable_id').val(id)
+
+    type = $link.data('commentable-type')
+    $reply.find('#commentable_type').val(type)
+
+    $reply.show()
+    $(this).hide()
+    false
+

--- a/app/views/opinio/comments/_comment.html.erb
+++ b/app/views/opinio/comments/_comment.html.erb
@@ -10,7 +10,7 @@
   <%# this enables only 1 level of replies %>
   <% if Opinio.accept_replies && !reply %>
     <% if send(Opinio.current_user_method) %>
-      <span><%= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true, data: { commentable_type: Opinio.model_name, commentable_id: comment.id } %></span>
+      <span><%= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true, class: 'reply_link', data: { commentable_type: Opinio.model_name, commentable_id: comment.id } %></span>
     <% end %>
     <ul id="comment_<%= comment.id %>_replies" class="replies">
       <%= render :partial => "opinio/comments/comment", :collection => comment.comments, :locals => {:reply => true} %>

--- a/app/views/opinio/comments/_comment.html.erb
+++ b/app/views/opinio/comments/_comment.html.erb
@@ -10,7 +10,7 @@
   <%# this enables only 1 level of replies %>
   <% if Opinio.accept_replies && !reply %>
     <% if send(Opinio.current_user_method) %>
-      <span><%= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true %></span>
+      <span><%= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true, data: { commentable_type: Opinio.model_name, commentable_id: comment.id } %></span>
     <% end %>
     <ul id="comment_<%= comment.id %>_replies" class="replies">
       <%= render :partial => "opinio/comments/comment", :collection => comment.comments, :locals => {:reply => true} %>

--- a/app/views/opinio/comments/_comment.html.haml
+++ b/app/views/opinio/comments/_comment.html.haml
@@ -7,6 +7,6 @@
   -# this enables only 1 level of replies
   -if Opinio.accept_replies && !reply
     - if send(Opinio.current_user_method)
-      %span= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true
+      %span= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true, data: { commentable_type: Opinio.model_name, commentable_id: comment.id }
     %ul.replies{:id => "comment_#{comment.id}_replies"}
       = render :partial => "opinio/comments/comment", :collection => comment.comments, :locals => {:reply => true}

--- a/app/views/opinio/comments/_comment.html.haml
+++ b/app/views/opinio/comments/_comment.html.haml
@@ -7,6 +7,6 @@
   -# this enables only 1 level of replies
   -if Opinio.accept_replies && !reply
     - if send(Opinio.current_user_method)
-      %span= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true, data: { commentable_type: Opinio.model_name, commentable_id: comment.id }
+      %span= link_to t('opinio.actions.reply'), reply_comment_path(comment), :remote => true, class: 'reply_link', data: { commentable_type: Opinio.model_name, commentable_id: comment.id }
     %ul.replies{:id => "comment_#{comment.id}_replies"}
       = render :partial => "opinio/comments/comment", :collection => comment.comments, :locals => {:reply => true}

--- a/app/views/opinio/comments/_reply_template.html.erb
+++ b/app/views/opinio/comments/_reply_template.html.erb
@@ -1,0 +1,8 @@
+<div id="reply_template" class='reply_template' style='display:none;'>
+  <%= form_for Comment.new, :remote => false do |f| %>
+    <p><%= f.text_area :body %></p>
+    <%= hidden_field_tag :commentable_id, nil %>
+    <%= hidden_field_tag :commentable_type, nil %>
+    <%= f.submit t('opinio.actions.add_reply') %>
+  <% end %>
+</div>

--- a/app/views/opinio/comments/_reply_template.html.erb
+++ b/app/views/opinio/comments/_reply_template.html.erb
@@ -1,8 +1,8 @@
 <div id="reply_template" class='reply_template' style='display:none;'>
   <%= form_for Comment.new, :remote => false do |f| %>
-    <p><%= f.text_area :body %></p>
+    <%= f.text_area :body, class: :reply_body %>
     <%= hidden_field_tag :commentable_id, nil %>
     <%= hidden_field_tag :commentable_type, nil %>
-    <%= f.submit t('opinio.actions.add_reply') %>
+    <%= f.submit t('opinio.actions.add_reply'), disabled: :disabled %>
   <% end %>
 </div>

--- a/app/views/opinio/comments/_reply_template.html.haml
+++ b/app/views/opinio/comments/_reply_template.html.haml
@@ -1,6 +1,6 @@
 #reply_template.reply_template{style: 'display:none;'}
   = form_for Comment.new, :remote => false do |f|
-    %p= f.text_area :body
+    = f.text_area :body, class: :reply_body
     = hidden_field_tag :commentable_id, nil
     = hidden_field_tag :commentable_type, nil
-    = f.submit t('opinio.actions.add_reply')
+    = f.submit t('opinio.actions.add_reply'), disabled: :disabled

--- a/app/views/opinio/comments/_reply_template.html.haml
+++ b/app/views/opinio/comments/_reply_template.html.haml
@@ -1,0 +1,6 @@
+#reply_template.reply_template{style: 'display:none;'}
+  = form_for Comment.new, :remote => false do |f|
+    %p= f.text_area :body
+    = hidden_field_tag :commentable_id, nil
+    = hidden_field_tag :commentable_type, nil
+    = f.submit t('opinio.actions.add_reply')

--- a/config/locales/opinio.en.yml
+++ b/config/locales/opinio.en.yml
@@ -4,6 +4,7 @@ en:
       delete: 'Delete'
       reply: 'Reply'
       add: 'Add comment'
+      add_reply: 'Add reply'
     messages:
       no_comments_found: 'No comments found'
       must_be_logged_in_to_comment: 'Must be logged in to comment.'

--- a/lib/opinio/controllers/helpers.rb
+++ b/lib/opinio/controllers/helpers.rb
@@ -2,7 +2,8 @@ module Opinio
   module Controllers
     module Helpers
 
-      def comments_for(object, options = {})        
+      def comments_for(object, options = {})
+        render_reply_templates +
         render_comments(object, options) +
         ( render_comments_form(object, options) unless options[:no_new] ).to_s
       end
@@ -16,7 +17,12 @@ module Opinio
       def render_comments_form(object, options = {})
         render( :partial => "opinio/comments/new", :locals => {:commentable => object, :options => options} )
       end
+
+      def render_reply_templates
+        return unless Opinio.accept_replies
+        render :partial => "opinio/comments/reply_template"
+      end
     end
-    
+
   end
 end


### PR DESCRIPTION
The 'reply' link associated with a comment now carries some information about the comment which is used to generate the reply form. No need to make a callback to the server.

I did not delete the old reply controller code but I think it should go away.

This is a WIP, extracted from a project so there may be some rough edges, like I wrote the HAML templates without testing them (scandal!) and we may want to improve the reply template styling (it is currently done in my client app). 

Tell me what you think!
